### PR TITLE
Update license headers to 2025 and include "and others"

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2024 Deutsche Telekom AG
+# SPDX-FileCopyrightText: 2025 Deutsche Telekom AG and others
 #
 # SPDX-License-Identifier: Apache-2.0
 

--- a/.github/workflows/gradle-publish.yml
+++ b/.github/workflows/gradle-publish.yml
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2024 Deutsche Telekom AG
+# SPDX-FileCopyrightText: 2025 Deutsche Telekom AG and others
 #
 # SPDX-License-Identifier: Apache-2.0
 

--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2024 Deutsche Telekom AG
+# SPDX-FileCopyrightText: 2025 Deutsche Telekom AG and others
 #
 # SPDX-License-Identifier: Apache-2.0
 

--- a/README.md
+++ b/README.md
@@ -354,7 +354,7 @@ This project has adopted the [Contributor Covenant](https://www.contributor-cove
 By participating in this project, you agree to abide by its [Code of Conduct](./CodeOfConduct.md) at all times.
 
 ## Licensing
-Copyright (c) 2024 Deutsche Telekom AG.
+Copyright (c) 2025 Deutsche Telekom AG and others.
 
 Sourcecode licensed under the [Apache License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0) (the "License"); you may not use this project except in compliance with the License.
 

--- a/REUSE.toml
+++ b/REUSE.toml
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2024 Deutsche Telekom AG
+# SPDX-FileCopyrightText: 2025 Deutsche Telekom AG and others
 # 
 # SPDX-License-Identifier: Apache-2.0
 

--- a/benchmarks/benchmark.ipynb.license
+++ b/benchmarks/benchmark.ipynb.license
@@ -1,3 +1,3 @@
-SPDX-FileCopyrightText: 2024 Deutsche Telekom AG
+SPDX-FileCopyrightText: 2025 Deutsche Telekom AG and others
 
 SPDX-License-Identifier: Apache-2.0

--- a/benchmarks/build.gradle.kts
+++ b/benchmarks/build.gradle.kts
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 Deutsche Telekom AG
+// SPDX-FileCopyrightText: 2025 Deutsche Telekom AG and others
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/benchmarks/docs/llm_analysis.png.license
+++ b/benchmarks/docs/llm_analysis.png.license
@@ -1,3 +1,3 @@
-SPDX-FileCopyrightText: 2024 Deutsche Telekom AG
+SPDX-FileCopyrightText: 2025 Deutsche Telekom AG and others
 
 SPDX-License-Identifier: Apache-2.0

--- a/benchmarks/docs/llm_confusion_matrix.png.license
+++ b/benchmarks/docs/llm_confusion_matrix.png.license
@@ -1,3 +1,3 @@
-SPDX-FileCopyrightText: 2024 Deutsche Telekom AG
+SPDX-FileCopyrightText: 2025 Deutsche Telekom AG and others
 
 SPDX-License-Identifier: Apache-2.0

--- a/benchmarks/docs/llm_prediction.csv.license
+++ b/benchmarks/docs/llm_prediction.csv.license
@@ -1,3 +1,3 @@
-SPDX-FileCopyrightText: 2024 Deutsche Telekom AG
+SPDX-FileCopyrightText: 2025 Deutsche Telekom AG and others
 
 SPDX-License-Identifier: Apache-2.0

--- a/benchmarks/docs/vector_analysis.png.license
+++ b/benchmarks/docs/vector_analysis.png.license
@@ -1,3 +1,3 @@
-SPDX-FileCopyrightText: 2024 Deutsche Telekom AG
+SPDX-FileCopyrightText: 2025 Deutsche Telekom AG and others
 
 SPDX-License-Identifier: Apache-2.0

--- a/benchmarks/docs/vector_confusion_matrix.png.license
+++ b/benchmarks/docs/vector_confusion_matrix.png.license
@@ -1,3 +1,3 @@
-SPDX-FileCopyrightText: 2024 Deutsche Telekom AG
+SPDX-FileCopyrightText: 2025 Deutsche Telekom AG and others
 
 SPDX-License-Identifier: Apache-2.0

--- a/benchmarks/docs/vector_prediction.csv.license
+++ b/benchmarks/docs/vector_prediction.csv.license
@@ -1,3 +1,3 @@
-SPDX-FileCopyrightText: 2024 Deutsche Telekom AG
+SPDX-FileCopyrightText: 2025 Deutsche Telekom AG and others
 
 SPDX-License-Identifier: Apache-2.0

--- a/benchmarks/src/main/kotlin/llm/LLMResolverBenchmark.kt
+++ b/benchmarks/src/main/kotlin/llm/LLMResolverBenchmark.kt
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 Deutsche Telekom AG
+// SPDX-FileCopyrightText: 2025 Deutsche Telekom AG and others
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/benchmarks/src/main/kotlin/vector/VectorResolverBenchmark.kt
+++ b/benchmarks/src/main/kotlin/vector/VectorResolverBenchmark.kt
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 Deutsche Telekom AG
+// SPDX-FileCopyrightText: 2025 Deutsche Telekom AG and others
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/benchmarks/src/main/resources/agentRoutingSpecs.json.license
+++ b/benchmarks/src/main/resources/agentRoutingSpecs.json.license
@@ -1,3 +1,3 @@
-SPDX-FileCopyrightText: 2024 Deutsche Telekom AG
+SPDX-FileCopyrightText: 2025 Deutsche Telekom AG and others
 
 SPDX-License-Identifier: Apache-2.0

--- a/benchmarks/src/main/resources/test.csv.license
+++ b/benchmarks/src/main/resources/test.csv.license
@@ -1,3 +1,3 @@
-SPDX-FileCopyrightText: 2024 Deutsche Telekom AG
+SPDX-FileCopyrightText: 2025 Deutsche Telekom AG and others
 
 SPDX-License-Identifier: Apache-2.0

--- a/benchmarks/src/main/resources/train.csv.license
+++ b/benchmarks/src/main/resources/train.csv.license
@@ -1,3 +1,3 @@
-SPDX-FileCopyrightText: 2024 Deutsche Telekom AG
+SPDX-FileCopyrightText: 2025 Deutsche Telekom AG and others
 
 SPDX-License-Identifier: Apache-2.0

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 Deutsche Telekom AG
+// SPDX-FileCopyrightText: 2025 Deutsche Telekom AG and others
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/lmos-router-core/build.gradle.kts
+++ b/lmos-router-core/build.gradle.kts
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 Deutsche Telekom AG
+// SPDX-FileCopyrightText: 2025 Deutsche Telekom AG and others
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/lmos-router-core/src/main/kotlin/org/eclipse/lmos/router/core/AgentRoutingSpec.kt
+++ b/lmos-router-core/src/main/kotlin/org/eclipse/lmos/router/core/AgentRoutingSpec.kt
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 Deutsche Telekom AG
+// SPDX-FileCopyrightText: 2025 Deutsche Telekom AG and others
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/lmos-router-core/src/main/kotlin/org/eclipse/lmos/router/core/AgentRoutingSpecsProvider.kt
+++ b/lmos-router-core/src/main/kotlin/org/eclipse/lmos/router/core/AgentRoutingSpecsProvider.kt
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 Deutsche Telekom AG
+// SPDX-FileCopyrightText: 2025 Deutsche Telekom AG and others
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/lmos-router-core/src/main/kotlin/org/eclipse/lmos/router/core/AgentRoutingSpecsResolver.kt
+++ b/lmos-router-core/src/main/kotlin/org/eclipse/lmos/router/core/AgentRoutingSpecsResolver.kt
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 Deutsche Telekom AG
+// SPDX-FileCopyrightText: 2025 Deutsche Telekom AG and others
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/lmos-router-core/src/main/kotlin/org/eclipse/lmos/router/core/Context.kt
+++ b/lmos-router-core/src/main/kotlin/org/eclipse/lmos/router/core/Context.kt
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 Deutsche Telekom AG
+// SPDX-FileCopyrightText: 2025 Deutsche Telekom AG and others
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/lmos-router-core/src/main/kotlin/org/eclipse/lmos/router/core/Input.kt
+++ b/lmos-router-core/src/main/kotlin/org/eclipse/lmos/router/core/Input.kt
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 Deutsche Telekom AG
+// SPDX-FileCopyrightText: 2025 Deutsche Telekom AG and others
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/lmos-router-core/src/main/kotlin/org/eclipse/lmos/router/core/Result.kt
+++ b/lmos-router-core/src/main/kotlin/org/eclipse/lmos/router/core/Result.kt
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 Deutsche Telekom AG
+// SPDX-FileCopyrightText: 2025 Deutsche Telekom AG and others
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/lmos-router-core/src/main/kotlin/org/eclipse/lmos/router/core/SpecFilter.kt
+++ b/lmos-router-core/src/main/kotlin/org/eclipse/lmos/router/core/SpecFilter.kt
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 Deutsche Telekom AG
+// SPDX-FileCopyrightText: 2025 Deutsche Telekom AG and others
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/lmos-router-core/src/test/kotlin/SampleFlow.kt
+++ b/lmos-router-core/src/test/kotlin/SampleFlow.kt
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 Deutsche Telekom AG
+// SPDX-FileCopyrightText: 2025 Deutsche Telekom AG and others
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/lmos-router-core/src/test/kotlin/org/eclipse/lmos/router/core/AgentRoutingSpecBuilderTest.kt
+++ b/lmos-router-core/src/test/kotlin/org/eclipse/lmos/router/core/AgentRoutingSpecBuilderTest.kt
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 Deutsche Telekom AG
+// SPDX-FileCopyrightText: 2025 Deutsche Telekom AG and others
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/lmos-router-core/src/test/kotlin/org/eclipse/lmos/router/core/AgentRoutingSpecsProviderTest.kt
+++ b/lmos-router-core/src/test/kotlin/org/eclipse/lmos/router/core/AgentRoutingSpecsProviderTest.kt
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 Deutsche Telekom AG
+// SPDX-FileCopyrightText: 2025 Deutsche Telekom AG and others
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/lmos-router-core/src/test/kotlin/org/eclipse/lmos/router/core/AgentRoutingSpecsResolverTest.kt
+++ b/lmos-router-core/src/test/kotlin/org/eclipse/lmos/router/core/AgentRoutingSpecsResolverTest.kt
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 Deutsche Telekom AG
+// SPDX-FileCopyrightText: 2025 Deutsche Telekom AG and others
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/lmos-router-core/src/test/kotlin/org/eclipse/lmos/router/core/ChatMessageTest.kt
+++ b/lmos-router-core/src/test/kotlin/org/eclipse/lmos/router/core/ChatMessageTest.kt
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 Deutsche Telekom AG
+// SPDX-FileCopyrightText: 2025 Deutsche Telekom AG and others
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/lmos-router-core/src/test/kotlin/org/eclipse/lmos/router/core/ContextTest.kt
+++ b/lmos-router-core/src/test/kotlin/org/eclipse/lmos/router/core/ContextTest.kt
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 Deutsche Telekom AG
+// SPDX-FileCopyrightText: 2025 Deutsche Telekom AG and others
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/lmos-router-core/src/test/kotlin/org/eclipse/lmos/router/core/ResultTest.kt
+++ b/lmos-router-core/src/test/kotlin/org/eclipse/lmos/router/core/ResultTest.kt
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 Deutsche Telekom AG
+// SPDX-FileCopyrightText: 2025 Deutsche Telekom AG and others
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/lmos-router-core/src/test/kotlin/org/eclipse/lmos/router/core/SpecFilterTest.kt
+++ b/lmos-router-core/src/test/kotlin/org/eclipse/lmos/router/core/SpecFilterTest.kt
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 Deutsche Telekom AG
+// SPDX-FileCopyrightText: 2025 Deutsche Telekom AG and others
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/lmos-router-hybrid-spring-boot-starter/build.gradle.kts
+++ b/lmos-router-hybrid-spring-boot-starter/build.gradle.kts
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 Deutsche Telekom AG
+// SPDX-FileCopyrightText: 2025 Deutsche Telekom AG and others
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/lmos-router-hybrid-spring-boot-starter/src/main/kotlin/org/eclipse/lmos/router/hybrid/starter/HybridAgentRoutingSpecsResolverAutoConfiguration.kt
+++ b/lmos-router-hybrid-spring-boot-starter/src/main/kotlin/org/eclipse/lmos/router/hybrid/starter/HybridAgentRoutingSpecsResolverAutoConfiguration.kt
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 Deutsche Telekom AG
+// SPDX-FileCopyrightText: 2025 Deutsche Telekom AG and others
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/lmos-router-hybrid-spring-boot-starter/src/main/kotlin/org/eclipse/lmos/router/hybrid/starter/HybridAgentRoutingSpecsResolverProperties.kt
+++ b/lmos-router-hybrid-spring-boot-starter/src/main/kotlin/org/eclipse/lmos/router/hybrid/starter/HybridAgentRoutingSpecsResolverProperties.kt
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 Deutsche Telekom AG
+// SPDX-FileCopyrightText: 2025 Deutsche Telekom AG and others
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/lmos-router-hybrid-spring-boot-starter/src/main/kotlin/org/eclipse/lmos/router/hybrid/starter/SpringModelClient.kt
+++ b/lmos-router-hybrid-spring-boot-starter/src/main/kotlin/org/eclipse/lmos/router/hybrid/starter/SpringModelClient.kt
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 Deutsche Telekom AG
+// SPDX-FileCopyrightText: 2025 Deutsche Telekom AG and others
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/lmos-router-hybrid-spring-boot-starter/src/main/kotlin/org/eclipse/lmos/router/hybrid/starter/SpringVectorSearchClient.kt
+++ b/lmos-router-hybrid-spring-boot-starter/src/main/kotlin/org/eclipse/lmos/router/hybrid/starter/SpringVectorSearchClient.kt
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 Deutsche Telekom AG
+// SPDX-FileCopyrightText: 2025 Deutsche Telekom AG and others
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/lmos-router-hybrid-spring-boot-starter/src/main/kotlin/org/eclipse/lmos/router/hybrid/starter/SpringVectorSearchClientProperties.kt
+++ b/lmos-router-hybrid-spring-boot-starter/src/main/kotlin/org/eclipse/lmos/router/hybrid/starter/SpringVectorSearchClientProperties.kt
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 Deutsche Telekom AG
+// SPDX-FileCopyrightText: 2025 Deutsche Telekom AG and others
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/lmos-router-hybrid-spring-boot-starter/src/main/kotlin/org/eclipse/lmos/router/hybrid/starter/SpringVectorSeedClient.kt
+++ b/lmos-router-hybrid-spring-boot-starter/src/main/kotlin/org/eclipse/lmos/router/hybrid/starter/SpringVectorSeedClient.kt
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 Deutsche Telekom AG
+// SPDX-FileCopyrightText: 2025 Deutsche Telekom AG and others
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/lmos-router-hybrid-spring-boot-starter/src/test/kotlin/org/eclipse/lmos/router/hybrid/starter/HybridAgentRoutingSpecsResolverAutoConfigurationTest.kt
+++ b/lmos-router-hybrid-spring-boot-starter/src/test/kotlin/org/eclipse/lmos/router/hybrid/starter/HybridAgentRoutingSpecsResolverAutoConfigurationTest.kt
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 Deutsche Telekom AG
+// SPDX-FileCopyrightText: 2025 Deutsche Telekom AG and others
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/lmos-router-hybrid-spring-boot-starter/src/test/kotlin/org/eclipse/lmos/router/hybrid/starter/SpringVectorSearchClientPropertiesTest.kt
+++ b/lmos-router-hybrid-spring-boot-starter/src/test/kotlin/org/eclipse/lmos/router/hybrid/starter/SpringVectorSearchClientPropertiesTest.kt
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 Deutsche Telekom AG
+// SPDX-FileCopyrightText: 2025 Deutsche Telekom AG and others
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/lmos-router-hybrid-spring-boot-starter/src/test/kotlin/org/eclipse/lmos/router/hybrid/starter/SpringVectorSearchClientTest.kt
+++ b/lmos-router-hybrid-spring-boot-starter/src/test/kotlin/org/eclipse/lmos/router/hybrid/starter/SpringVectorSearchClientTest.kt
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 Deutsche Telekom AG
+// SPDX-FileCopyrightText: 2025 Deutsche Telekom AG and others
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/lmos-router-hybrid-spring-boot-starter/src/test/kotlin/org/eclipse/lmos/router/hybrid/starter/SpringVectorSeedClientTest.kt
+++ b/lmos-router-hybrid-spring-boot-starter/src/test/kotlin/org/eclipse/lmos/router/hybrid/starter/SpringVectorSeedClientTest.kt
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 Deutsche Telekom AG
+// SPDX-FileCopyrightText: 2025 Deutsche Telekom AG and others
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/lmos-router-hybrid/build.gradle.kts
+++ b/lmos-router-hybrid/build.gradle.kts
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 Deutsche Telekom AG
+// SPDX-FileCopyrightText: 2025 Deutsche Telekom AG and others
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/lmos-router-hybrid/src/main/kotlin/org/eclipse/lmos/router/hybrid/HybridAgentRoutingSpecsResolver.kt
+++ b/lmos-router-hybrid/src/main/kotlin/org/eclipse/lmos/router/hybrid/HybridAgentRoutingSpecsResolver.kt
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 Deutsche Telekom AG
+// SPDX-FileCopyrightText: 2025 Deutsche Telekom AG and others
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/lmos-router-hybrid/src/main/kotlin/org/eclipse/lmos/router/hybrid/ModelToVectorQueryConverter.kt
+++ b/lmos-router-hybrid/src/main/kotlin/org/eclipse/lmos/router/hybrid/ModelToVectorQueryConverter.kt
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 Deutsche Telekom AG
+// SPDX-FileCopyrightText: 2025 Deutsche Telekom AG and others
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/lmos-router-hybrid/src/test/kotlin/SampleHybridFlow.kt
+++ b/lmos-router-hybrid/src/test/kotlin/SampleHybridFlow.kt
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 Deutsche Telekom AG
+// SPDX-FileCopyrightText: 2025 Deutsche Telekom AG and others
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/lmos-router-hybrid/src/test/kotlin/org/eclipse/lmos/router/hybrid/HybridAgentRoutingSpecsResolverTest.kt
+++ b/lmos-router-hybrid/src/test/kotlin/org/eclipse/lmos/router/hybrid/HybridAgentRoutingSpecsResolverTest.kt
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 Deutsche Telekom AG
+// SPDX-FileCopyrightText: 2025 Deutsche Telekom AG and others
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/lmos-router-hybrid/src/test/kotlin/org/eclipse/lmos/router/hybrid/ModelToVectorQueryConverterTest.kt
+++ b/lmos-router-hybrid/src/test/kotlin/org/eclipse/lmos/router/hybrid/ModelToVectorQueryConverterTest.kt
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 Deutsche Telekom AG
+// SPDX-FileCopyrightText: 2025 Deutsche Telekom AG and others
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/lmos-router-hybrid/src/test/kotlin/org/eclipse/lmos/router/hybrid/NoOpModelToVectorQueryConverterTest.kt
+++ b/lmos-router-hybrid/src/test/kotlin/org/eclipse/lmos/router/hybrid/NoOpModelToVectorQueryConverterTest.kt
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 Deutsche Telekom AG
+// SPDX-FileCopyrightText: 2025 Deutsche Telekom AG and others
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/lmos-router-llm-in-spring-cloud-gateway-demo/Demo-setup.jpg.license
+++ b/lmos-router-llm-in-spring-cloud-gateway-demo/Demo-setup.jpg.license
@@ -1,3 +1,3 @@
-SPDX-FileCopyrightText: 2024 Deutsche Telekom AG
+SPDX-FileCopyrightText: 2025 Deutsche Telekom AG and others
 
 SPDX-License-Identifier: Apache-2.0

--- a/lmos-router-llm-in-spring-cloud-gateway-demo/build.gradle.kts
+++ b/lmos-router-llm-in-spring-cloud-gateway-demo/build.gradle.kts
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 Deutsche Telekom AG
+// SPDX-FileCopyrightText: 2025 Deutsche Telekom AG and others
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/lmos-router-llm-in-spring-cloud-gateway-demo/src/main/kotlin/org/eclipse/lmos/router/demo/agent/AgentsApplication.kt
+++ b/lmos-router-llm-in-spring-cloud-gateway-demo/src/main/kotlin/org/eclipse/lmos/router/demo/agent/AgentsApplication.kt
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 Deutsche Telekom AG
+// SPDX-FileCopyrightText: 2025 Deutsche Telekom AG and others
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/lmos-router-llm-in-spring-cloud-gateway-demo/src/main/kotlin/org/eclipse/lmos/router/demo/agent/inbound/AgentsController.kt
+++ b/lmos-router-llm-in-spring-cloud-gateway-demo/src/main/kotlin/org/eclipse/lmos/router/demo/agent/inbound/AgentsController.kt
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 Deutsche Telekom AG
+// SPDX-FileCopyrightText: 2025 Deutsche Telekom AG and others
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/lmos-router-llm-in-spring-cloud-gateway-demo/src/main/kotlin/org/eclipse/lmos/router/demo/gateway/LmosRouterGatewayApplication.kt
+++ b/lmos-router-llm-in-spring-cloud-gateway-demo/src/main/kotlin/org/eclipse/lmos/router/demo/gateway/LmosRouterGatewayApplication.kt
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 Deutsche Telekom AG
+// SPDX-FileCopyrightText: 2025 Deutsche Telekom AG and others
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/lmos-router-llm-in-spring-cloud-gateway-demo/src/main/resources/application.yml
+++ b/lmos-router-llm-in-spring-cloud-gateway-demo/src/main/resources/application.yml
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2024 Deutsche Telekom AG
+# SPDX-FileCopyrightText: 2025 Deutsche Telekom AG and others
 #
 # SPDX-License-Identifier: Apache-2.0
 

--- a/lmos-router-llm-spring-boot-starter/build.gradle.kts
+++ b/lmos-router-llm-spring-boot-starter/build.gradle.kts
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 Deutsche Telekom AG
+// SPDX-FileCopyrightText: 2025 Deutsche Telekom AG and others
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/lmos-router-llm-spring-boot-starter/src/main/kotlin/org/eclipse/lmos/router/llm/starter/LLMAgentRoutingSpecsResolverAutoConfiguration.kt
+++ b/lmos-router-llm-spring-boot-starter/src/main/kotlin/org/eclipse/lmos/router/llm/starter/LLMAgentRoutingSpecsResolverAutoConfiguration.kt
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 Deutsche Telekom AG
+// SPDX-FileCopyrightText: 2025 Deutsche Telekom AG and others
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/lmos-router-llm-spring-boot-starter/src/main/kotlin/org/eclipse/lmos/router/llm/starter/LLMAgentRoutingSpecsResolverProperties.kt
+++ b/lmos-router-llm-spring-boot-starter/src/main/kotlin/org/eclipse/lmos/router/llm/starter/LLMAgentRoutingSpecsResolverProperties.kt
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 Deutsche Telekom AG
+// SPDX-FileCopyrightText: 2025 Deutsche Telekom AG and others
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/lmos-router-llm-spring-boot-starter/src/main/kotlin/org/eclipse/lmos/router/llm/starter/SpringModelClient.kt
+++ b/lmos-router-llm-spring-boot-starter/src/main/kotlin/org/eclipse/lmos/router/llm/starter/SpringModelClient.kt
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 Deutsche Telekom AG
+// SPDX-FileCopyrightText: 2025 Deutsche Telekom AG and others
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/lmos-router-llm-spring-boot-starter/src/test/kotlin/SpringLLMAgentResolverFlow.kt
+++ b/lmos-router-llm-spring-boot-starter/src/test/kotlin/SpringLLMAgentResolverFlow.kt
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 Deutsche Telekom AG
+// SPDX-FileCopyrightText: 2025 Deutsche Telekom AG and others
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/lmos-router-llm-spring-boot-starter/src/test/kotlin/org/eclipse/lmos/router/llm/starter/LLMAgentRoutingSpecsResolverAutoConfigurationTest.kt
+++ b/lmos-router-llm-spring-boot-starter/src/test/kotlin/org/eclipse/lmos/router/llm/starter/LLMAgentRoutingSpecsResolverAutoConfigurationTest.kt
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 Deutsche Telekom AG
+// SPDX-FileCopyrightText: 2025 Deutsche Telekom AG and others
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/lmos-router-llm/build.gradle.kts
+++ b/lmos-router-llm/build.gradle.kts
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 Deutsche Telekom AG
+// SPDX-FileCopyrightText: 2025 Deutsche Telekom AG and others
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/lmos-router-llm/src/main/kotlin/org/eclipse/lmos/router/llm/LLMAgentRoutingSpecsResolver.kt
+++ b/lmos-router-llm/src/main/kotlin/org/eclipse/lmos/router/llm/LLMAgentRoutingSpecsResolver.kt
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 Deutsche Telekom AG
+// SPDX-FileCopyrightText: 2025 Deutsche Telekom AG and others
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/lmos-router-llm/src/main/kotlin/org/eclipse/lmos/router/llm/LangChainModelClient.kt
+++ b/lmos-router-llm/src/main/kotlin/org/eclipse/lmos/router/llm/LangChainModelClient.kt
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 Deutsche Telekom AG
+// SPDX-FileCopyrightText: 2025 Deutsche Telekom AG and others
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/lmos-router-llm/src/main/kotlin/org/eclipse/lmos/router/llm/ModelClient.kt
+++ b/lmos-router-llm/src/main/kotlin/org/eclipse/lmos/router/llm/ModelClient.kt
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 Deutsche Telekom AG
+// SPDX-FileCopyrightText: 2025 Deutsche Telekom AG and others
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/lmos-router-llm/src/main/kotlin/org/eclipse/lmos/router/llm/ModelClientResponse.kt
+++ b/lmos-router-llm/src/main/kotlin/org/eclipse/lmos/router/llm/ModelClientResponse.kt
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 Deutsche Telekom AG
+// SPDX-FileCopyrightText: 2025 Deutsche Telekom AG and others
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/lmos-router-llm/src/main/kotlin/org/eclipse/lmos/router/llm/ModelPromptProvider.kt
+++ b/lmos-router-llm/src/main/kotlin/org/eclipse/lmos/router/llm/ModelPromptProvider.kt
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 Deutsche Telekom AG
+// SPDX-FileCopyrightText: 2025 Deutsche Telekom AG and others
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/lmos-router-llm/src/test/kotlin/SampleLLMFlow.kt
+++ b/lmos-router-llm/src/test/kotlin/SampleLLMFlow.kt
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 Deutsche Telekom AG
+// SPDX-FileCopyrightText: 2025 Deutsche Telekom AG and others
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/lmos-router-llm/src/test/kotlin/ai/eclipse/lmos/router/org/DefaultModelClientTest.kt
+++ b/lmos-router-llm/src/test/kotlin/ai/eclipse/lmos/router/org/DefaultModelClientTest.kt
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 Deutsche Telekom AG
+// SPDX-FileCopyrightText: 2025 Deutsche Telekom AG and others
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/lmos-router-llm/src/test/kotlin/ai/eclipse/lmos/router/org/LLMAgentRoutingSpecsResolverTest.kt
+++ b/lmos-router-llm/src/test/kotlin/ai/eclipse/lmos/router/org/LLMAgentRoutingSpecsResolverTest.kt
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 Deutsche Telekom AG
+// SPDX-FileCopyrightText: 2025 Deutsche Telekom AG and others
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/lmos-router-llm/src/test/kotlin/ai/eclipse/lmos/router/org/LangChainChatModelFactoryTest.kt
+++ b/lmos-router-llm/src/test/kotlin/ai/eclipse/lmos/router/org/LangChainChatModelFactoryTest.kt
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 Deutsche Telekom AG
+// SPDX-FileCopyrightText: 2025 Deutsche Telekom AG and others
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/lmos-router-llm/src/test/kotlin/ai/eclipse/lmos/router/org/LangChainModelClientTest.kt
+++ b/lmos-router-llm/src/test/kotlin/ai/eclipse/lmos/router/org/LangChainModelClientTest.kt
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 Deutsche Telekom AG
+// SPDX-FileCopyrightText: 2025 Deutsche Telekom AG and others
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/lmos-router-vector-spring-boot-starter/build.gradle.kts
+++ b/lmos-router-vector-spring-boot-starter/build.gradle.kts
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 Deutsche Telekom AG
+// SPDX-FileCopyrightText: 2025 Deutsche Telekom AG and others
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/lmos-router-vector-spring-boot-starter/src/main/kotlin/org/eclipse/lmos/router/vector/starter/SpringVectorSearchClient.kt
+++ b/lmos-router-vector-spring-boot-starter/src/main/kotlin/org/eclipse/lmos/router/vector/starter/SpringVectorSearchClient.kt
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 Deutsche Telekom AG
+// SPDX-FileCopyrightText: 2025 Deutsche Telekom AG and others
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/lmos-router-vector-spring-boot-starter/src/main/kotlin/org/eclipse/lmos/router/vector/starter/SpringVectorSearchClientProperties.kt
+++ b/lmos-router-vector-spring-boot-starter/src/main/kotlin/org/eclipse/lmos/router/vector/starter/SpringVectorSearchClientProperties.kt
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 Deutsche Telekom AG
+// SPDX-FileCopyrightText: 2025 Deutsche Telekom AG and others
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/lmos-router-vector-spring-boot-starter/src/main/kotlin/org/eclipse/lmos/router/vector/starter/SpringVectorSeedClient.kt
+++ b/lmos-router-vector-spring-boot-starter/src/main/kotlin/org/eclipse/lmos/router/vector/starter/SpringVectorSeedClient.kt
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 Deutsche Telekom AG
+// SPDX-FileCopyrightText: 2025 Deutsche Telekom AG and others
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/lmos-router-vector-spring-boot-starter/src/main/kotlin/org/eclipse/lmos/router/vector/starter/VectorAgentRoutingSpecsResolverAutoConfiguration.kt
+++ b/lmos-router-vector-spring-boot-starter/src/main/kotlin/org/eclipse/lmos/router/vector/starter/VectorAgentRoutingSpecsResolverAutoConfiguration.kt
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 Deutsche Telekom AG
+// SPDX-FileCopyrightText: 2025 Deutsche Telekom AG and others
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/lmos-router-vector-spring-boot-starter/src/main/kotlin/org/eclipse/lmos/router/vector/starter/VectorAgentRoutingSpecsResolverProperties.kt
+++ b/lmos-router-vector-spring-boot-starter/src/main/kotlin/org/eclipse/lmos/router/vector/starter/VectorAgentRoutingSpecsResolverProperties.kt
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 Deutsche Telekom AG
+// SPDX-FileCopyrightText: 2025 Deutsche Telekom AG and others
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/lmos-router-vector-spring-boot-starter/src/test/kotlin/SpringVectorAgentRoutingSpecsResolverFlow.kt
+++ b/lmos-router-vector-spring-boot-starter/src/test/kotlin/SpringVectorAgentRoutingSpecsResolverFlow.kt
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 Deutsche Telekom AG
+// SPDX-FileCopyrightText: 2025 Deutsche Telekom AG and others
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/lmos-router-vector-spring-boot-starter/src/test/kotlin/org/eclipse/lmos/router/vector/starter/SpringVectorSearchClientPropertiesTest.kt
+++ b/lmos-router-vector-spring-boot-starter/src/test/kotlin/org/eclipse/lmos/router/vector/starter/SpringVectorSearchClientPropertiesTest.kt
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 Deutsche Telekom AG
+// SPDX-FileCopyrightText: 2025 Deutsche Telekom AG and others
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/lmos-router-vector-spring-boot-starter/src/test/kotlin/org/eclipse/lmos/router/vector/starter/SpringVectorSearchClientTest.kt
+++ b/lmos-router-vector-spring-boot-starter/src/test/kotlin/org/eclipse/lmos/router/vector/starter/SpringVectorSearchClientTest.kt
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 Deutsche Telekom AG
+// SPDX-FileCopyrightText: 2025 Deutsche Telekom AG and others
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/lmos-router-vector-spring-boot-starter/src/test/kotlin/org/eclipse/lmos/router/vector/starter/SpringVectorSeedClientTest.kt
+++ b/lmos-router-vector-spring-boot-starter/src/test/kotlin/org/eclipse/lmos/router/vector/starter/SpringVectorSeedClientTest.kt
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 Deutsche Telekom AG
+// SPDX-FileCopyrightText: 2025 Deutsche Telekom AG and others
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/lmos-router-vector-spring-boot-starter/src/test/kotlin/org/eclipse/lmos/router/vector/starter/VectorAgentRoutingSpecsResolverAutoConfigurationTest.kt
+++ b/lmos-router-vector-spring-boot-starter/src/test/kotlin/org/eclipse/lmos/router/vector/starter/VectorAgentRoutingSpecsResolverAutoConfigurationTest.kt
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 Deutsche Telekom AG
+// SPDX-FileCopyrightText: 2025 Deutsche Telekom AG and others
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/lmos-router-vector-spring-boot-starter/src/test/kotlin/org/eclipse/lmos/router/vector/starter/VectorAgentRoutingSpecsResolverPropertiesTest.kt
+++ b/lmos-router-vector-spring-boot-starter/src/test/kotlin/org/eclipse/lmos/router/vector/starter/VectorAgentRoutingSpecsResolverPropertiesTest.kt
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 Deutsche Telekom AG
+// SPDX-FileCopyrightText: 2025 Deutsche Telekom AG and others
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/lmos-router-vector/build.gradle.kts
+++ b/lmos-router-vector/build.gradle.kts
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 Deutsche Telekom AG
+// SPDX-FileCopyrightText: 2025 Deutsche Telekom AG and others
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/lmos-router-vector/src/main/kotlin/org/eclipse/lmos/router/vector/EmbeddingClient.kt
+++ b/lmos-router-vector/src/main/kotlin/org/eclipse/lmos/router/vector/EmbeddingClient.kt
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 Deutsche Telekom AG
+// SPDX-FileCopyrightText: 2025 Deutsche Telekom AG and others
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/lmos-router-vector/src/main/kotlin/org/eclipse/lmos/router/vector/Models.kt
+++ b/lmos-router-vector/src/main/kotlin/org/eclipse/lmos/router/vector/Models.kt
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 Deutsche Telekom AG
+// SPDX-FileCopyrightText: 2025 Deutsche Telekom AG and others
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/lmos-router-vector/src/main/kotlin/org/eclipse/lmos/router/vector/Utils.kt
+++ b/lmos-router-vector/src/main/kotlin/org/eclipse/lmos/router/vector/Utils.kt
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 Deutsche Telekom AG
+// SPDX-FileCopyrightText: 2025 Deutsche Telekom AG and others
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/lmos-router-vector/src/main/kotlin/org/eclipse/lmos/router/vector/VectorAgentRoutingSpecsResolver.kt
+++ b/lmos-router-vector/src/main/kotlin/org/eclipse/lmos/router/vector/VectorAgentRoutingSpecsResolver.kt
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 Deutsche Telekom AG
+// SPDX-FileCopyrightText: 2025 Deutsche Telekom AG and others
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/lmos-router-vector/src/main/kotlin/org/eclipse/lmos/router/vector/VectorClient.kt
+++ b/lmos-router-vector/src/main/kotlin/org/eclipse/lmos/router/vector/VectorClient.kt
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 Deutsche Telekom AG
+// SPDX-FileCopyrightText: 2025 Deutsche Telekom AG and others
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/lmos-router-vector/src/test/kotlin/SampleVectorFlow.kt
+++ b/lmos-router-vector/src/test/kotlin/SampleVectorFlow.kt
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 Deutsche Telekom AG
+// SPDX-FileCopyrightText: 2025 Deutsche Telekom AG and others
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/lmos-router-vector/src/test/kotlin/org/eclipse/lmos/router/vector/CosineSimilarityTest.kt
+++ b/lmos-router-vector/src/test/kotlin/org/eclipse/lmos/router/vector/CosineSimilarityTest.kt
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 Deutsche Telekom AG
+// SPDX-FileCopyrightText: 2025 Deutsche Telekom AG and others
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/lmos-router-vector/src/test/kotlin/org/eclipse/lmos/router/vector/VectorAgentRoutingSpecsResolverTest.kt
+++ b/lmos-router-vector/src/test/kotlin/org/eclipse/lmos/router/vector/VectorAgentRoutingSpecsResolverTest.kt
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 Deutsche Telekom AG
+// SPDX-FileCopyrightText: 2025 Deutsche Telekom AG and others
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/lmos-router-vector/src/test/kotlin/org/eclipse/lmos/router/vector/VectorClientTest.kt
+++ b/lmos-router-vector/src/test/kotlin/org/eclipse/lmos/router/vector/VectorClientTest.kt
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 Deutsche Telekom AG
+// SPDX-FileCopyrightText: 2025 Deutsche Telekom AG and others
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 Deutsche Telekom AG
+// SPDX-FileCopyrightText: 2025 Deutsche Telekom AG and others
 //
 // SPDX-License-Identifier: Apache-2.0
 


### PR DESCRIPTION
See https://www.eclipse.org/projects/handbook/#ip-copyright-headers