### PR TITLE
Add support for chat models from Azure-OpenAI

### DIFF
--- a/lmos-router-llm/build.gradle.kts
+++ b/lmos-router-llm/build.gradle.kts
@@ -8,6 +8,7 @@ dependencies {
     implementation("org.jetbrains.kotlinx:kotlinx-serialization-json-jvm:1.7.3")
     implementation("dev.langchain4j:langchain4j-open-ai:0.36.2")
     implementation("dev.langchain4j:langchain4j-anthropic:0.36.2")
+    implementation("dev.langchain4j:langchain4j-azure-open-ai:0.36.2")
     implementation("dev.langchain4j:langchain4j-google-ai-gemini:0.36.2")
     implementation("dev.langchain4j:langchain4j-ollama:0.36.2")
 }

--- a/lmos-router-llm/src/main/kotlin/org/eclipse/lmos/router/llm/LangChainModelClient.kt
+++ b/lmos-router-llm/src/main/kotlin/org/eclipse/lmos/router/llm/LangChainModelClient.kt
@@ -6,6 +6,7 @@ package org.eclipse.lmos.router.llm
 
 import dev.langchain4j.data.message.AiMessage
 import dev.langchain4j.model.anthropic.AnthropicChatModel
+import dev.langchain4j.model.azure.AzureOpenAiChatModel
 import dev.langchain4j.model.chat.ChatLanguageModel
 import dev.langchain4j.model.chat.request.ResponseFormat
 import dev.langchain4j.model.chat.request.ResponseFormatType
@@ -85,6 +86,22 @@ class LangChainChatModelFactory private constructor() {
                     model.build()
                 }
 
+                LangChainClientProvider.AZURE_OPENAI.name.lowercase() -> {
+                    require(properties.baseUrl != null) { "baseUrl is required for '${LangChainClientProvider.AZURE_OPENAI.name.lowercase()}' provider" }
+
+                    val model =
+                        AzureOpenAiChatModel.builder()
+                            .endpoint(properties.baseUrl)
+                            .apiKey(properties.apiKey)
+                            .deploymentName(properties.model)
+                            .maxTokens(properties.maxTokens)
+                            .temperature(properties.temperature)
+
+                    properties.topP?.let { model.topP(it) }
+
+                    model.build()
+                }
+
                 LangChainClientProvider.GEMINI.name.lowercase() -> {
                     val model =
                         GoogleAiGeminiChatModel.builder()
@@ -142,6 +159,7 @@ class LangChainChatModelFactory private constructor() {
 enum class LangChainClientProvider {
     OPENAI,
     ANTHROPIC,
+    AZURE_OPENAI,
     GEMINI,
     OLLAMA,
     OTHER,


### PR DESCRIPTION
Currently, the router supports openai chat models, but not the openai chat models provided by azure.

This PR adds support for azure-openai by using langchain4j's library for azure-openai.

One question I asked myself was: Why not use the langchain4j library for openai instead (which is already used in the lmos-router, in particular for the model type "OTHER"). I tried making things work with model type "OTHER" (cf. [here](https://github.com/eclipse-lmos/lmos-router/blob/74a7fcd33881dddd19d6710c548ddfc5cf084088/lmos-router-llm/src/main/kotlin/org/eclipse/lmos/router/llm/LangChainModelClient.kt#L118)), but could not make it work. Why? Azure seems to require the api-version to be set as query parameter in its URL (without the api-version, I always got a 404); however, from what I see langchain4j's `OpenAiChatModelBuilder` does not provide a way to set the api-version (although it is in principle supported by the openai client used by langchain4j, they just don't provide that option in langchain4j). And that's why I fell back to using the special azure-openai support from langchain4j.

One more comment on this PR: With the current implementation of the lmos-runtime, the lmos-runtime will not work with azure-openai in the lmos-router, because the azure-openai lib uses blocking calls when talking to azure's HTTP API - and this currently makes lmos-router fail when using lmos-router with an azure-openai LLM. However, in my opinion this is an issue in lmos-runtime, and I will propose a PR for lmos-runtime to resolve that issue there.