### PR TITLE
Tell gradle to use junit5 for testing (unit tests are not run without that)

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -76,6 +76,8 @@ subprojects {
         if (!runFlowTests) {
             exclude("**/*Flow*")
         }
+
+        useJUnitPlatform()
     }
 
     mavenPublishing {


### PR DESCRIPTION
Without this change, gradle does not find any tests (and therefore does not execute any tests), at least on my machine.