### PR TITLE
Fix ktlint issues that were introduced with commit 7998e3e371cec06c09d9279777b11ce8ae9da211

### DIFF
--- a/lmos-router-llm/src/main/kotlin/org/eclipse/lmos/router/llm/LangChainModelClient.kt
+++ b/lmos-router-llm/src/main/kotlin/org/eclipse/lmos/router/llm/LangChainModelClient.kt
@@ -14,6 +14,7 @@ import dev.langchain4j.model.googleai.GoogleAiGeminiChatModel
 import dev.langchain4j.model.ollama.OllamaChatModel
 import dev.langchain4j.model.openai.OpenAiChatModel.OpenAiChatModelBuilder
 import org.eclipse.lmos.router.core.*
+import org.eclipse.lmos.router.llm.LangChainClientProvider.AZURE_OPENAI
 
 /**
  * A model client that uses Langchain4j(https://docs.langchain4j.dev/) to call a language model.
@@ -86,8 +87,8 @@ class LangChainChatModelFactory private constructor() {
                     model.build()
                 }
 
-                LangChainClientProvider.AZURE_OPENAI.name.lowercase() -> {
-                    require(properties.baseUrl != null) { "baseUrl is required for '${LangChainClientProvider.AZURE_OPENAI.name.lowercase()}' provider" }
+                AZURE_OPENAI.name.lowercase() -> {
+                    require(properties.baseUrl != null) { "baseUrl is required for '${AZURE_OPENAI.name.lowercase()}' provider" }
 
                     val model =
                         AzureOpenAiChatModel.builder()


### PR DESCRIPTION
This change fixes the ktlint issue that slipped through with https://github.com/eclipse-lmos/lmos-router/commit/7998e3e371cec06c09d9279777b11ce8ae9da211 ("line too long").

Note: Unfortunately, even with this fix the build is still broken, but unrelated to the changes from https://github.com/eclipse-lmos/lmos-router/commit/7998e3e371cec06c09d9279777b11ce8ae9da211. There is a compile issue that is also present in the commits before https://github.com/eclipse-lmos/lmos-router/commit/7998e3e371cec06c09d9279777b11ce8ae9da211, probably due to using SNAPSHOT-versions of the spring-ai-core lib. Need to investigate this, but wanted to get the ktlint issues fixed already to not bother others with it...

