### PR TITLE
forward causing exception

### DIFF
--- a/lmos-classifier-vector/src/main/kotlin/org/eclipse/lmos/classifier/vector/retriever/QdrantEmbeddingRetriever.kt
+++ b/lmos-classifier-vector/src/main/kotlin/org/eclipse/lmos/classifier/vector/retriever/QdrantEmbeddingRetriever.kt
@@ -37,7 +37,7 @@ class QdrantEmbeddingRetriever(
             val embeddings = contents.mapNotNull { it.convert() }
             return embeddings
         } catch (e: RuntimeException) {
-            throw TenantNotSupportedException("No collection found for tenant '${context.tenantId}' and channel '${context.channelId}'.")
+            throw TenantNotSupportedException("No collection found for tenant '${context.tenantId}' and channel '${context.channelId}'.", e)
         }
     }
 


### PR DESCRIPTION
On TenantNotSupportedException the causing exception isn't forwarded which makes debugging hard